### PR TITLE
SUP-1880 - Make possible translation of strings to english.

### DIFF
--- a/ding_language.admin.inc
+++ b/ding_language.admin.inc
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ */
+
+/**
+ * Ding language settings form.
+ */
+function ding_language_settings_form() {
+  $form['ding_language'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Ding Language Settings'),
+    '#description' => t('Change Ding Language related settings.'),
+  ];
+
+  $form['ding_language']['ding_language_translate_groups'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Translate text groups'),
+    '#description' => t('Check the textgoups which should be translateable for all enabled languages.'),
+    '#collapsible' => TRUE,
+  ];
+
+  $groups = module_invoke_all('locale', 'groups');
+
+  $form['ding_language']['ding_language_translate_groups']['ding_language_text_groups'] = [
+    '#type' => 'checkboxes',
+    '#title' => t('Text groups'),
+    '#options' => $groups,
+    '#default_value' => variable_get('ding_language_text_groups', []),
+  ];
+
+  return system_settings_form($form);
+}

--- a/ding_language.info
+++ b/ding_language.info
@@ -20,3 +20,4 @@ features[features_overrides][] = variable.language_negotiation_language_url.valu
 features[features_overrides][] = variable.languageicons_path.value
 features[variable][] = ding_language_random
 features[variable][] = i18n_hide_translation_links
+configure = admin/config/ding/language

--- a/ding_language.install
+++ b/ding_language.install
@@ -55,10 +55,3 @@ function ding_language_install() {
 
   variable_set('ding_language_random', rand());
 }
-
-/**
- * Set source language as danish.
- */
-function ding_language_update_7001() {
-  variable_set('i18n_string_source_language', 'da');
-}

--- a/ding_language.module
+++ b/ding_language.module
@@ -8,6 +8,25 @@
 include_once 'ding_language.features.inc';
 
 /**
+ * Implements hook_menu().
+ */
+function ding_language_menu() {
+  $items = [];
+
+  $items['admin/config/ding/language'] = [
+    'title' => 'Ding Language',
+    'description' => 'Ding Language settings form.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => ['ding_language_settings_form'],
+    'file' => 'ding_language.admin.inc',
+    'access arguments' => ['access administration pages'],
+    'type' => MENU_NORMAL_ITEM,
+  ];
+
+  return $items;
+}
+
+/**
  * Implements hook_views_query_alter().
  */
 function ding_language_views_query_alter(&$view, &$query) {
@@ -375,5 +394,40 @@ function ding_language_page_build(&$page) {
     $page_content = variable_get('customerror_404_' . $language->language, $default_customerror_body);
     $return = $page_content['value'];
     drupal_set_page_content($return);
+  }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function ding_language_form_i18n_string_locale_translate_edit_form_alter(&$form, &$form_state, $form_id) {
+  $groups = variable_get('ding_language_text_groups', []);
+  $groups = array_filter($groups);
+
+  if (!empty($groups) && in_array($form['textgroup']['#value'], $groups)) {
+    $lid = $form["lid"]["#value"];
+    $source = db_query('SELECT source, context, textgroup, location FROM {locales_source} WHERE lid = :lid', [':lid' => $lid])->fetchObject();
+
+    // Include default form controls with empty values for all languages.
+    // This ensures that the languages are always in the same order in forms.
+    $languages = language_list();
+
+    $form['translations'] = ['#tree' => TRUE];
+    // Approximate the number of rows to use in the default textarea.
+    $rows = min(ceil(str_word_count($source->source) / 12), 10);
+    foreach ($languages as $langcode => $language) {
+      $form['translations'][$langcode] = [
+        '#type' => 'textarea',
+        '#title' => t($language->name),
+        '#rows' => $rows,
+        '#default_value' => '',
+      ];
+    }
+
+    // Fetch translations and fill in default values in the form.
+    $result = db_query("SELECT DISTINCT translation, language FROM {locales_target} WHERE lid = :lid", [':lid' => $lid]);
+    foreach ($result as $translation) {
+      $form['translations'][$translation->language]['#default_value'] = $translation->translation;
+    }
   }
 }


### PR DESCRIPTION
- Added functionality which checks from which text group is translated string and allow translation of this for all enabled languages.
- Added module settings form at `admin/config/ding/language` where user can choose on which textgroups can be translated in all languages.

After code delivery:

1. Go to `admin/config/ding/language` and tick the desired textgroups and save the form. (_Ex: Ting facets translation strings are kept in EasyOPAC textgroup_).
2. Go to Translate interface page and translate needed strings. 