### PR TITLE
EASYOPAC-1294 - Remove overriding of EUCC module 'Agree' button label.

### DIFF
--- a/ding_language.module
+++ b/ding_language.module
@@ -496,22 +496,6 @@ function ding_language_form_i18n_string_locale_translate_edit_form_alter(&$form,
 /**
  * Implements hook_preprocess_HOOK().
  */
-function ding_language_preprocess_eu_cookie_compliance_popup_info(&$variables) {
-  global $language;
-
-  $enabled_languages = language_list();
-  // Filter enabled languages to find the non-core one.
-  $non_default_langs = array_diff(array_keys($enabled_languages), ['da', 'en']);
-  // Use default translatable `en` value for agree  button when current language
-  // don't match the core ones.
-  if (in_array($language->language, $non_default_langs)) {
-    $variables['agree_button'] = t('OK, I agree');
-  }
-}
-
-/**
- * Implements hook_preprocess_HOOK().
- */
 function ding_language_preprocess_panels_pane(&$variables) {
   if ($variables['pane']->subtype === 'block-1') {
     global $language;

--- a/ding_language.module
+++ b/ding_language.module
@@ -496,6 +496,27 @@ function ding_language_form_i18n_string_locale_translate_edit_form_alter(&$form,
 /**
  * Implements hook_preprocess_HOOK().
  */
+function ding_language_preprocess_eu_cookie_compliance_popup_info(&$variables) {
+  global $language;
+
+  if (empty($variables['agree_button'])) {
+    $enabled_languages = language_list();
+    // Filter enabled languages to find the non-core one.
+    $non_default_langs = array_diff(array_keys($enabled_languages), [
+      'da',
+      'en'
+    ]);
+    // Use default translatable `en` value for agree  button when current language
+    // don't match the core ones.
+    if (in_array($language->language, $non_default_langs)) {
+      $variables['agree_button'] = t('OK, I agree');
+    }
+  }
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
 function ding_language_preprocess_panels_pane(&$variables) {
   if ($variables['pane']->subtype === 'block-1') {
     global $language;


### PR DESCRIPTION
This code was overriding the EU Cookie Compliance module "Agree" button label so this could be translated. 

For now this is un-useful because we can individually set the label's text for each language activated, more than that this was overriding indicated label text in module's configuration form.